### PR TITLE
Update Taxonomy

### DIFF
--- a/app/content/datasets/black-marble-blue-yellow-noaa.mdx
+++ b/app/content/datasets/black-marble-blue-yellow-noaa.mdx
@@ -12,14 +12,14 @@ media:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
       - Earthquakes
       - Wildfires
       - Floods
       - Volcanoes
       - Industrial Incidents
       - Landslides
-      - Severe & Winter Weather
+      - Severe and Winter Weather
   - name: Source
     values:
       - NASA

--- a/app/content/datasets/black-marble-blue-yellow-noaa.mdx
+++ b/app/content/datasets/black-marble-blue-yellow-noaa.mdx
@@ -10,21 +10,30 @@ media:
     name:  Earth Observatory NASA
     url:  https://earthobservatory.nasa.gov
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Land
-      - Aquatic    
+      - Hurricanes & Cyclones
+      - Earthquakes
+      - Wildfires
+      - Floods
+      - Volcanoes
+      - Industrial Incidents
+      - Landslides
+      - Severe & Winter Weather
   - name: Source
     values:
       - NASA
       - NOAA
-  - name: Gas
-    values:
-      - CH₄
-      - CO₂
   - name: Product Type
     values:
-      - Satellite Observations
+      - NRT
+  - name: Event
+    values:
+      - 2024 Hurricane Helene
+      - 2025 Burma Earthquake
+      - 2024 Hurricane Milton
+      - 2025 California Wildfires
+
 infoDescription: |
   ::markdown 
     - Temporal Extent: October 10, 2023 - Ongoing

--- a/app/content/datasets/burma-eq.mdx
+++ b/app/content/datasets/burma-eq.mdx
@@ -3,25 +3,26 @@ id: burma-eq
 name: Datasets Supporting 2025 Burma Earthquake Data Story
 isHidden: false
 description: Datasets supporting the data story on the damaging March 28, 2025 Burma magnitude 7.7 earthquake. 
-
 media:
   src: /images/story/burma-eq-background.jpg
   alt: Collapsed building in Mandalay, Burma.
   author:
     name: Cai Yang/AP
-
 taxonomy:
-  - name: Topics
-    values:
-      - Natural Disasters
-  - name: Subtopics
+  - name: Disaster
     values:
       - Earthquakes
   - name: Source
     values:
-      - NASA JPL
-      - Black Marble
-      - Planet
+      - NASA
+      - Planet Labs
+  - name: Product Type
+    values:
+      - Ad Hoc
+      - NRT
+  - name: Event
+    values:
+      - 2025 Burma Earthquake
 
 infoDescription: |
   ::markdown

--- a/app/content/datasets/ca-wildfires-2025.mdx
+++ b/app/content/datasets/ca-wildfires-2025.mdx
@@ -8,15 +8,20 @@ media:
   author:
     name:  NASA
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Disasters
+      - Wildfires
   - name: Source
     values:
       - NASA
+  - name: Product Type
+    values:
+      - NRT
+      - Ad Hoc
   - name: Event
     values:
-      - CA Wildfire      
+      - 2025 California Wildfires   
+
 infoDescription: |
   ::markdown
     - Temporal Extent: January 6, 2025 - January 15, 2025

--- a/app/content/datasets/hurricane-helene-2024.mdx
+++ b/app/content/datasets/hurricane-helene-2024.mdx
@@ -10,21 +10,21 @@ media:
     name:  Earth Observatory NASA
     url:  https://earthobservatory.nasa.gov
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Land
-      - Aquatic    
+      - Hurricanes & Cyclones
   - name: Source
     values:
       - NASA
       - NOAA
-  - name: Gas
-    values:
-      - CH₄
-      - CO₂
   - name: Product Type
     values:
-      - Satellite Observations
+      - Ad Hoc
+      - NRT
+  - name: Event
+    values:
+      - 2024 Hurricane Helene
+
 infoDescription: |
   ::markdown 
     - Temporal Extent: October 10, 2023 - Ongoing

--- a/app/content/datasets/hurricane-helene-2024.mdx
+++ b/app/content/datasets/hurricane-helene-2024.mdx
@@ -12,7 +12,7 @@ media:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
   - name: Source
     values:
       - NASA

--- a/app/content/datasets/hurricane-milton-2024.mdx
+++ b/app/content/datasets/hurricane-milton-2024.mdx
@@ -10,21 +10,21 @@ media:
     name:  Earth Observatory NASA
     url:  https://earthobservatory.nasa.gov
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Land
-      - Aquatic    
+      - Hurricanes & Cyclones
   - name: Source
     values:
       - NASA
       - NOAA
-  - name: Gas
-    values:
-      - CH₄
-      - CO₂
   - name: Product Type
     values:
-      - Satellite Observations
+      - NRT
+      - Ad Hoc
+  - name: Event
+    values:
+      - 2024 Hurricane Milton
+      
 infoDescription: |
   ::markdown 
     - Temporal Extent: October 10, 2023 - Ongoing

--- a/app/content/datasets/hurricane-milton-2024.mdx
+++ b/app/content/datasets/hurricane-milton-2024.mdx
@@ -12,7 +12,7 @@ media:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
   - name: Source
     values:
       - NASA

--- a/app/content/datasets/lis-alaska-nrt.mdx
+++ b/app/content/datasets/lis-alaska-nrt.mdx
@@ -10,17 +10,20 @@ media:
     name:  Figure by Mike
     url:  https://stock.adobe.com/images/medenhall-glacier-outlook-juneau-alaska/138501742?prev_url=detail
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Agriculture
-      - Climate
-      - Drought
-      - Evapotranspiration
-      - Hydrology
-      - Water Resources
+      - Hurricanes & Cyclones
+      - Wildfires
+      - Floods
+      - Landslides
+      - Severe & Winter Weather
   - name: Source
     values:
       - NASA
+  - name: Product Type
+    values:
+      - NRT
+
 infoDescription: |
   ::markdown
     - Temporal Extent: June 1, 2010 - Present

--- a/app/content/datasets/lis-alaska-nrt.mdx
+++ b/app/content/datasets/lis-alaska-nrt.mdx
@@ -12,11 +12,11 @@ media:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
       - Wildfires
       - Floods
       - Landslides
-      - Severe & Winter Weather
+      - Severe and Winter Weather
   - name: Source
     values:
       - NASA

--- a/app/content/datasets/lis-conus-nrt.mdx
+++ b/app/content/datasets/lis-conus-nrt.mdx
@@ -10,17 +10,20 @@ media:
     name:  Figure by Loic
     url:  https://as1.ftcdn.net/v2/jpg/02/23/42/98/1000_F_223429826_1f1lL7wGycwZQoyFlXL8p7tAXS59NqdE.jpg
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Agriculture
-      - Climate
-      - Drought
-      - Evapotranspiration
-      - Hydrology
-      - Water Resources
+      - Hurricanes & Cyclones
+      - Wildfires
+      - Floods
+      - Landslides
+      - Severe & Winter Weather
   - name: Source
     values:
       - NASA
+  - name: Product Type
+    values:
+      - NRT
+      
 infoDescription: |
   ::markdown
     - Temporal Extent: 30 days prior - present

--- a/app/content/datasets/lis-conus-nrt.mdx
+++ b/app/content/datasets/lis-conus-nrt.mdx
@@ -12,11 +12,11 @@ media:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
       - Wildfires
       - Floods
       - Landslides
-      - Severe & Winter Weather
+      - Severe and Winter Weather
   - name: Source
     values:
       - NASA

--- a/app/content/events/burma-eq.mdx
+++ b/app/content/events/burma-eq.mdx
@@ -9,9 +9,9 @@ media:
   author:
     name: Cai Yang/AP
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Disasters
+      - Earthquakes
 
 ---
 

--- a/app/content/events/ca-wildfire-2025.mdx
+++ b/app/content/events/ca-wildfire-2025.mdx
@@ -10,9 +10,9 @@ media:
     url: https://www.sfchronicle.com/travel/article/hawaii-fire-maui-lahaina-18289213.php
 pubDate: 2025-05-20
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Wildfire
+      - Wildfires
 ---
 
 <Block>

--- a/app/content/events/hurricane-helene-2024.mdx
+++ b/app/content/events/hurricane-helene-2024.mdx
@@ -12,7 +12,7 @@ taxonomy:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
 
 ---
 

--- a/app/content/events/hurricane-helene-2024.mdx
+++ b/app/content/events/hurricane-helene-2024.mdx
@@ -9,7 +9,6 @@ media:
   author:
     name: NASA Worldview
 taxonomy:
-taxonomy:
   - name: Disaster
     values:
       - Hurricanes and Cyclones

--- a/app/content/events/hurricane-helene-2024.mdx
+++ b/app/content/events/hurricane-helene-2024.mdx
@@ -9,9 +9,10 @@ media:
   author:
     name: NASA Worldview
 taxonomy:
-  - name: Topics
+taxonomy:
+  - name: Disaster
     values:
-      - Disasters
+      - Hurricanes & Cyclones
 
 ---
 

--- a/app/content/events/hurricane-milton-2024.mdx
+++ b/app/content/events/hurricane-milton-2024.mdx
@@ -9,7 +9,7 @@ media:
 taxonomy:
   - name: Disaster
     values:
-      - Hurricanes & Cyclones
+      - Hurricanes and Cyclones
 
 ---
 

--- a/app/content/events/hurricane-milton-2024.mdx
+++ b/app/content/events/hurricane-milton-2024.mdx
@@ -7,9 +7,10 @@ media:
   src: /images/story/milton-iss-1.png
   alt: satellite view of hurricane milton
 taxonomy:
-  - name: Topics
+  - name: Disaster
     values:
-      - Disasters
+      - Hurricanes & Cyclones
+
 ---
 
 <Block>


### PR DESCRIPTION
Updated Dataset Taxonomy as follows:
- Disaster (follows 8 standardized disaster topic tags)
- Source (restricted to agency; i.e., NASA, NOAA)
- Product Type (either NRT or Ad Hoc - can change this wording later)
- Event (standardized labelling as Date Location Disaster Type; example: 2025 Burma Earthquake) 

and Event Taxonomy as follows:
- Disaster (follows 8 standardized disaster topic tags)