### PR TITLE
fix(mapblock): implement new veda-ui MapBlock API

### DIFF
--- a/app/components/mdx-components/block.tsx
+++ b/app/components/mdx-components/block.tsx
@@ -1,19 +1,129 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useDataStore } from 'app/store/providers/data';
 import { MapBlock, ScrollytellingBlock } from '@lib';
-import { transformToVedaData } from 'app/content/utils/data';
+import { transformToVedaData } from 'app/utilities/data';
+import { DatasetStatus, type VizDatasetSuccess } from 'app/types/veda-ui';
 
-export function EnhancedMapBlock(props) {
+/**
+ * Extracts layers from a specific dataset in the VEDA data structure.
+ * 
+ * @param vedaData - The transformed VEDA data object containing all datasets
+ * @param datasetId - The ID of the dataset to extract layers from
+ * @returns Object containing the dataset layers, or empty object if not found
+ */
+function getDatasetLayers(vedaData: any, datasetId?: string) {
+  if (!datasetId) return {};
+  const ds = vedaData?.[datasetId];
+  return ds?.data?.layers ? { [datasetId]: ds.data.layers } : {};
+}
+
+/**
+ * Searches for a layer by ID across all datasets in the layers record.
+ * 
+ * @param layersRecord - Record of dataset IDs to their layer arrays
+ * @param layerId - The ID of the layer to find
+ * @returns The found layer object, or null if not found
+ */
+function findLayerById(layersRecord: Record<string, any[]>, layerId?: string) {
+  if (!layerId) return null;
+  for (const dsId of Object.keys(layersRecord)) {
+    const match = (layersRecord[dsId] || []).find((l) => l.id === layerId);
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * Converts a raw layer object to the VizDatasetSuccess format expected by MapBlock.
+ * 
+ * @param layer - The raw layer object from the dataset
+ * @returns VizDatasetSuccess object with standardized structure, or null if layer is invalid
+ */
+function toVizDatasetSuccess(layer: any): VizDatasetSuccess | null {
+  if (!layer) return null;
+  return {
+    status: DatasetStatus.SUCCESS,
+    error: null,
+    id: layer.id,
+    name: layer.name,
+    type: layer.type,
+    data: layer,
+    settings: {
+      isVisible: true,
+      opacity: 100,
+    },
+  };
+}
+
+/**
+ * Enhanced MapBlock component that implements the new veda-ui MapBlock API.
+ * 
+ * This component addresses the changes introduced in veda-ui PR #1808, where MapBlock
+ * now expects pre-prepared baseDataLayer and compareDataLayer instead of full datasets.
+ * 
+ * The component:
+ * 1. Extracts the specified layer from the dataset
+ * 2. Converts it to the VizDatasetSuccess format
+ * 3. Handles comparison layers (both explicit and implicit via layer.compare)
+ * 4. Passes the prepared layers to the underlying MapBlock
+ * 
+ * @param datasetId - The ID of the dataset containing the layer
+ * @param layerId - The ID of the specific layer to display
+ * @param compareDataLayer - Optional override for comparison layer
+ * @param props - Additional props passed to the underlying MapBlock
+ * @returns JSX element containing the MapBlock with prepared data layers
+ */
+export function EnhancedMapBlock({
+  datasetId,
+  layerId,
+  compareDataLayer: compareOverride,
+  ...props
+}: {
+  datasetId: string;
+  layerId: string;
+  compareDataLayer?: any;
+  [key: string]: any;
+}) {
   const { datasets } = useDataStore();
-  const transformed = transformToVedaData(datasets);
-  return <MapBlock {...props} datasets={transformed} />;
-};
+  const transformed = useMemo(() => transformToVedaData(datasets), [datasets]);
 
+  const { baseDataLayer, compareDataLayer } = useMemo(() => {
+    const layersRecord = getDatasetLayers(transformed, datasetId);
+
+    const baseRaw = findLayerById(layersRecord, layerId);
+    const base = toVizDatasetSuccess(baseRaw);
+
+    let compare = compareOverride ?? null;
+    if (!compare && baseRaw?.compare?.layerId) {
+      const cmpRaw = findLayerById(layersRecord, baseRaw.compare.layerId);
+      compare = toVizDatasetSuccess(cmpRaw);
+    }
+
+    return { baseDataLayer: base, compareDataLayer: compare };
+  }, [transformed, datasetId, layerId, compareOverride]);
+
+  return (
+    <MapBlock
+      {...props}
+      baseDataLayer={baseDataLayer}
+      compareDataLayer={compareDataLayer}
+    />
+  );
+}
+
+/**
+ * Enhanced ScrollyTellingBlock component that provides datasets to the underlying component.
+ * 
+ * This component transforms the raw dataset metadata into the VEDA data format
+ * and passes it to the ScrollyTellingBlock component for interactive storytelling.
+ * 
+ * @param props - Props passed to the underlying ScrollyTellingBlock component
+ * @returns JSX element containing the ScrollyTellingBlock with transformed datasets
+ */
 export function EnhancedScrollyTellingBlock(props) {
   const { datasets } = useDataStore();
   const transformed = transformToVedaData(datasets);
   return <ScrollytellingBlock {...props} datasets={transformed} />;
 }
-

--- a/app/types/veda-ui.ts
+++ b/app/types/veda-ui.ts
@@ -1,0 +1,30 @@
+/**
+ * Temporary local re-declarations of types that exist inside @teamimpact/veda-ui
+ * but are not yet exported in its public API.
+ *
+ * These allow us to stay type-safe (instead of using @ts-nocheck) when working with
+ * MapBlock and related components in this repo.
+ *
+ * Once veda-ui exports these types officially, this file should be removed
+ * and imports switched back to @teamimpact/veda-ui (via app/lib/index.ts).
+ *
+ * Tracking issue on the veda-ui side: https://github.com/NASA-IMPACT/veda-ui/issues/1845
+ */
+export enum DatasetStatus {
+  SUCCESS = 'success',
+  LOADING = 'loading',
+  ERROR = 'error',
+}
+
+export interface VizDatasetSuccess {
+  status: DatasetStatus.SUCCESS;
+  error: null;
+  id: string;
+  name: string;
+  type: string;
+  data: any;
+  settings: {
+    isVisible: boolean;
+    opacity: number;
+  };
+}

--- a/app/utilities/data.ts
+++ b/app/utilities/data.ts
@@ -1,0 +1,63 @@
+import type { DatasetData, StoryData, VedaData } from '@lib';
+import type { DatasetMetadata } from 'app/types/content';
+
+/**
+ * Processes taxonomy data by converting values to lowercase IDs and preserving names.
+ * 
+ * This function normalizes taxonomy values by:
+ * - Converting spaces to underscores
+ * - Converting to lowercase for IDs
+ * - Preserving original names for display
+ * 
+ * @param data - Dataset or story data containing taxonomy information
+ * @returns Processed data with normalized taxonomy values
+ */
+export function processTaxonomies(data): DatasetData | StoryData {
+  const updatedTax = data.taxonomy.map((t) => {
+    const updatedVals = t.values.map((v) => {
+      return {
+        id: v.replace(/ /g, '_').toLowerCase(),
+        name: v,
+      };
+    });
+    return { ...t, values: updatedVals };
+  });
+  return { ...data, taxonomy: updatedTax };
+}
+
+/**
+ * Transforms an array of dataset metadata into a list of DatasetData objects.
+ * 
+ * @param content - Array of dataset metadata objects
+ * @returns Array of DatasetData objects
+ */
+export const transformToDatasetsList = (
+  content: DatasetMetadata[],
+): DatasetData[] => {
+  return content?.map((post) => ({
+    ...post.metadata,
+  }));
+};
+
+/**
+ * Transforms dataset metadata into the VEDA data format expected by components.
+ * 
+ * This function creates a nested object structure where each dataset ID maps
+ * to an object containing the dataset's metadata. This format is used by
+ * MapBlock and other VEDA UI components.
+ * 
+ * @param datasets - Array of dataset metadata objects
+ * @returns VEDA data object with dataset ID as keys
+ */
+export const transformToVedaData = (
+  datasets: DatasetMetadata[] | undefined,
+): VedaData<DatasetData> => {
+  const transformed = {};
+  datasets?.map((dataset) => {
+    const id = dataset.metadata.id;
+    transformed[id] = {
+      data: dataset.metadata,
+    };
+  });
+  return transformed;
+};


### PR DESCRIPTION
Implements the new veda-ui MapBlock API from PR [#1808](https://github.com/NASA-IMPACT/veda-ui/pull/1808) to fix STAC requests and WMTS layer rendering issues after veda-ui upgrades.

- Updated EnhancedMapBlock to prepare baseDataLayer and compareDataLayer
- Added VizDatasetSuccess type definitions
- Moved data utilities to dedicated module
- Added comprehensive JSDoc documentation

To test, visit event page `/events/hurricane-milton-2024` and confirm wmts is loading.

This is ready for review.