### PR TITLE
Create enforce-dev-to-main.yml

### DIFF
--- a/.github/workflows/enforce-dev-to-main.yml
+++ b/.github/workflows/enforce-dev-to-main.yml
@@ -1,0 +1,19 @@
+name: Enforce Dev to Main
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from dev branch
+        run: |
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "❌ Error: Pull requests to 'main' can only come from 'dev' branch."
+            echo "Your PR is from: ${{ github.head_ref }}"
+            exit 1
+          else
+            echo "✅ PR is correctly coming from dev branch"
+          fi


### PR DESCRIPTION
Github action to enforce that no branches can be merged into `main` except `dev`